### PR TITLE
Refactor to remove template literals from string nodes

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -30,7 +30,7 @@ export default () => (
         engineering team.
       </Paragraph>
       <Paragraph>
-        {`This is a living document. `}
+        This is a living document.{" "}
         <Link href={`https://github.com/barnardos/engineering-culture`}>
           Changes are encouraged
         </Link>


### PR DESCRIPTION
Let prettier handle whitespace inside them instead.